### PR TITLE
Fixing a problem of calling @runtime and it being nil.

### DIFF
--- a/lib/guard/haml-coffee.rb
+++ b/lib/guard/haml-coffee.rb
@@ -50,6 +50,8 @@ module Guard
     end
 
     def run_on_changes(paths)
+      start unless @runtime
+
       paths.each do |path|
         basename = File.basename(path, '.js.hamlc')
         output_file = get_output(path)


### PR DESCRIPTION
I had this problem when trying to run guard from a Ruby script like this:

```
Guard.setup no_interactions: true
Guard.run_all({})
```

I guess it's different than running just the `guard` command.
